### PR TITLE
added ability to add and remove answer cells

### DIFF
--- a/quiz_mill/filter_notebook.py
+++ b/quiz_mill/filter_notebook.py
@@ -24,7 +24,7 @@ import click
 @click.command()
 @click.argument("jupyin", type=str, nargs=1)
 @click.argument("jupyout", type=str, nargs=1)
-@click.option("-r", "--remove", is_flag=True, help="Remove answer cells") # remove currently doesn't do anything
+@click.option("-r", "--remove", is_flag=True, help="Remove answer cells")
 @click.option("-a", "--add", is_flag=True, help="Add answer cells with answers")
 def main(jupyin,jupyout, remove, add):
     in_file = Path(jupyin).resolve()

--- a/quiz_mill/filter_notebook.py
+++ b/quiz_mill/filter_notebook.py
@@ -1,4 +1,8 @@
-g"""
+from notebooks.two_layers import find_temps
+import sys
+sys.path.insert(1, '../notebooks')
+import two_layers
+"""
 This script goes through all the cells in a notebook
 and sets the ctype metadata to 'question' and adds
 a question number.  Then it makes a second pass through 
@@ -20,7 +24,9 @@ import click
 @click.command()
 @click.argument("jupyin", type=str, nargs=1)
 @click.argument("jupyout", type=str, nargs=1)
-def main(jupyin,jupyout):
+@click.option("-r", "--remove", is_flag=True, help="Remove answer cells") # remove currently doesn't do anything
+@click.option("-a", "--add", is_flag=True, help="Add answer cells with answers")
+def main(jupyin,jupyout, remove, add):
     in_file = Path(jupyin).resolve()
     out_file = Path(jupyout).resolve()
     print(in_file,out_file)
@@ -32,16 +38,37 @@ def main(jupyin,jupyout):
     for count,the_cell in enumerate(nb['cells']):
         the_cell['metadata']['ctype']='question'
         the_cell['metadata']['quesnum']=count
-    new_cells = []
-    for a_cell in nb['cells']:
-        new_cells.append(a_cell)
-        num = a_cell['metadata']['quesnum']
-        source = f"q{num} answer here"
-        answer = new_markdown_cell(source=source)
-        answer['metadata']['quesnum']=a_cell['metadata']['quesnum']
-        answer['metadata']['ctype']='answer'
-        new_cells.append(answer)
-    nb['cells'] = new_cells
+
+    # add an answer cell after each question cell
+    # currently only adds answers for q2 and q3
+    if add:
+        answers = get_answers()
+        i = 0
+        new_cells = []
+        for a_cell in nb['cells']:
+            new_cells.append(a_cell)
+            num = a_cell['metadata']['quesnum']
+            
+            answer = 'here'
+            if num in [2, 3]:
+                answer = ': ' + str(answers[i])
+                i += 1
+            source = f"q{num} answer {answer}"
+            
+            answer = new_markdown_cell(source=source)
+            answer['metadata']['quesnum']=a_cell['metadata']['quesnum']
+            answer['metadata']['ctype']='answer'
+            new_cells.append(answer)
+        nb['cells'] = new_cells
+
+    # remove answer cells
+    if remove:
+        new_cells = []
+        for a_cell in nb['cells']:
+            if a_cell['metadata']['ctype'] != 'answer':
+                new_cells.append(a_cell)
+            
+        nb['cells'] = new_cells
     #
     # write two versions of the notebook -- md and ipynb
     #
@@ -49,6 +76,22 @@ def main(jupyin,jupyout):
     jp.write(nb,out_file,fmt='md:myst')
     out_file = out_file.with_suffix('.ipynb')
     jp.write(nb,out_file)
+
+
+# get answers from two_layers.py
+def get_answers():
+    # get parameters
+    sol = two_layers.sol
+    epsilon1 = two_layers.epsilon1
+    epsilon2 = two_layers.epsilon2
+    albedo = two_layers.albedo
+
+    # get question answers
+    q1 = two_layers.do_two(sol, epsilon1, albedo)
+    q2 = two_layers.do_two_matrix(sol, epsilon1, epsilon2, albedo)
+    
+    return [q1, q2]
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Issue [ #56](https://github.com/eoas-ubc/eoas_tlef/issues/56)

Added two new click options: --add and --remove which add and remove answer cells, respectively. The --add option also includes the answers in the cell (currently only for q1 and q2)

> * [x] read about how to use setup.py to install command line tools: https://godatadriven.com/blog/a-practical-guide-to-using-setup-py/
> * [x] read about how to use click to document command line tools: https://click.palletsprojects.com/en/8.0.x/
> * [x] use filter-notebook to add and remove notebook cells