### PR TITLE
able to send quizzes to canvas

### DIFF
--- a/quiz_mill/filter_notebook.py
+++ b/quiz_mill/filter_notebook.py
@@ -42,54 +42,57 @@ def main(jupyin,jupyout, remove, add):
 
     # Iterate through each unfiltered notebook and filter it
     for _, _, files in os.walk(in_folder, topdown=False):
+
+        quiz_num = 1
         
         for in_file in files:
             nb = jp.read(in_folder / in_file)
 
-            # Parameters
-            parameter_cell = ""
+            new_cells = []
+
+            # Add quiz metadata
+            quiz = new_markdown_cell(source=f"# Two Layers Quiz {quiz_num}")
+            quiz["metadata"]["ctype"] = "quiz"
+            quiz["metadata"]["title"] = f"Two Layers Quiz {quiz_num}"
+            quiz["metadata"]["allowed_attempts"] = 3
+            quiz["metadata"]["scoring_policy"] = "keep_highest"
+            quiz["metadata"]["cant_go_back"] = False
+            quiz["metadata"]["shuffle_answers"] = False
+            new_cells.append(quiz)
+            quiz_num += 1
+
+            # Add group metadata
+            group = new_markdown_cell(source="## Questions")
+            group["metadata"]["ctype"] = "group"
+            group["metadata"]["name"] = "general"
+            new_cells.append(group)
+
+            # Get parameters
             sol = 0.0
             epsilon1 = 0.0
             epsilon2 = 0.0
             albedo = 0.0
-            
-            # Keep notebook cells up to and including parameter cells 
-            # (but remove cell containing default parameters)
-            original_cells = []
             for _, the_cell in enumerate(nb['cells']):
-                
-                # Do not include parameter cell
-                if (
-                    len(the_cell["metadata"]["tags"]) > 0 and 
-                    the_cell["metadata"]["tags"][0] == "parameters"
-                    ):
-                    continue 
-
-                original_cells.append(the_cell)
-
-                # Get injected parameters for use in answer cell
                 if (
                     len(the_cell["metadata"]["tags"]) > 0 and 
                     the_cell["metadata"]["tags"][0] == "injected-parameters"
                     ):
-                    parameter_cell = the_cell["source"]
-                    parameters = list(parameter_cell.split('\n')[1:-1])
+                    parameters = list(the_cell["source"].split('\n')[1:-1])
                     sol = float(re.sub("^sol = ", "", parameters[0]))
                     epsilon1 = float(re.sub("^epsilon1 = ", "", parameters[1]))
                     epsilon2 = float(re.sub("^epsilon2 = ", "", parameters[2]))
                     albedo = float(re.sub("^albedo = ", "", parameters[3]))
-                    break # Stop adding cells when we reach injected parameters cell
+                    break
 
-            new_cells = []
-
-            # Add question cells for student book
-            source = """\
-{}
+            # Add question cells
+            source = f"""\
+### Question 1
+sol = {sol}, epsilon1 = {epsilon1}, epsilon2 = {epsilon2}, albedo = {albedo}
 
 Given the above parameters, find the temperature of layer 1.
 
 Give your answer to three decimal places.\
-""".format(parameter_cell)
+"""
             question = new_markdown_cell(source=source)
             question["metadata"]["quesnum"]='1'
             question["metadata"]["ctype"]='question'
@@ -97,7 +100,7 @@ Give your answer to three decimal places.\
             new_cells.append(question)
 
             # Save student notebook
-            nb['cells'] = original_cells + new_cells
+            nb['cells'] = new_cells
             out_file = out_folder / "student" / f"{in_file[:-6]}_student"
             out_file = out_file.with_suffix('.md')
             jp.write(nb,out_file,fmt='md:myst')
@@ -106,26 +109,14 @@ Give your answer to three decimal places.\
 
             # Add solutions
             T1 = do_two_matrix(sol, albedo, epsilon1, epsilon2)[1]
-            source = "* {:0.2f}, 3: precision_answer".format(T1)
+            source = "* {:0.3f}, 3: precision_answer".format(T1)
             answer0 = new_markdown_cell(source=source)
             answer0['metadata']['quesnum'] = '1'
             answer0['metadata']['ctype']='answer'
             new_cells.append(answer0)
-            source = """Check this with Python:
-
-```{code-cell} ipython3
-:ctype: answer
-:quesnum: 1
-
-np.testing.assert_almost_equal(ans,6.383,decimals=3)
-```"""
-            answer1 = new_markdown_cell(source=source)
-            answer1['metadata']['quesnum'] = '1'
-            answer1['metadata']['ctype']='answer'
-            new_cells.append(answer1)
             
             # Save solution notebook
-            nb['cells'] = original_cells + new_cells
+            nb['cells'] = new_cells
             out_file = out_folder / "solution" / f"{in_file[:-6]}_solution"
             print(out_file)
             out_file = out_file.with_suffix('.md')

--- a/quiz_mill/send_to_canvas.sh
+++ b/quiz_mill/send_to_canvas.sh
@@ -1,0 +1,5 @@
+files=`ls notebooks/output/filtered/solution/*md`
+for file in $files
+do
+    md2canvas $file -f token.txt -c 51824 -u https://canvas.ubc.ca -s
+done


### PR DESCRIPTION
Issue [ #56](https://github.com/eoas-ubc/eoas_tlef/issues/56)
>- [x] add metadata to produce "precision answer" quiz (item 5) following https://github.com/phaustin/eoas-wl/blob/main/md2canvas/examples/demo_quiz/demo.md
>- [ ] write a bash script to produce 10 student and 10 instructor notebooks
>- [ ] move the bash script to python ala generate_notebooks.py (pha)
>- [x] push the 10 student notebooks to canvas using https://github.com/phaustin/eoas-wl
---
### My general workflow to generate and push quizzes to canvas
Note: all commands run from outermost **quiz-mill/** folder
1. Remove all files from **notebooks/output/** folder
```find notebooks/output/ -type f -exec rm -v {} \;```
2. Generate 10 notebooks with random parameters
```python quiz_mill/generate_notebooks.py -n 10```
3. Filter notebooks into student and solution notebooks versions
```filter-notebook notebooks/output/unfiltered/ notebooks/output/filtered/```
4. Send all quizzes in **notebooks/output/filtered/solution/** to canvas
```sh quiz_mill/send_to_canvas.sh``` (need token to run this command)
 